### PR TITLE
fixes inverted `ip_allowlist` length validation

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -101,7 +101,7 @@ variable "ip_allowlist" {
   default     = []
 
   validation {
-    condition     = length(var.ip_allowlist) > 50
+    condition     = length(var.ip_allowlist) <= 50
     error_message = "`ip_allowlist` must be at most 50 entries."
   }
 }


### PR DESCRIPTION
## Problem

The `ip_allowlist` validation asserts the opposite of what its error message describes:

```hcl
validation {
  condition     = length(var.ip_allowlist) > 50
  error_message = "`ip_allowlist` must be at most 50 entries."
}
```

A validation `condition` must evaluate to `true` to pass, so this rejects every list of **50 or fewer** entries — including the variable's own `[]` default.

The effect is that the module cannot be consumed at all on `v1.5.0` unless the caller passes more than 50 CIDRs. A minimal configuration using only required inputs fails at validate time:

```
Error: Invalid value for variable

`ip_allowlist` must be at most 50 entries.

This was checked by the validation rule at .terraform/modules/t/variables.tf:103,3-13.
```

Introduced in 608c428 (#10); `v1.2.0`–`v1.4.0` are unaffected as they carry no such rule.

## Fix

Invert the comparison to `<=`, matching the error message and the [HCP provider's documented 50-CIDR limit](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/resources/vault_cluster#ip_allowlist).

## Verification

Against a minimal caller passing only `cluster_id`, `hvn_id` and `project_id`:

| `ip_allowlist` | Before | After |
|---|---|---|
| `[]` (default) | ❌ rejected | ✅ accepted |
| 50 entries | ❌ rejected | ✅ accepted |
| 51 entries | ✅ accepted | ❌ rejected |

`terraform fmt -check -recursive` is clean.